### PR TITLE
add writecar method that avoids traversing a passed set of CID's

### DIFF
--- a/car_test.go
+++ b/car_test.go
@@ -19,7 +19,7 @@ func assertAddNodes(t *testing.T, ds format.DAGService, nds ...format.Node) {
 	}
 }
 
-func TestRoundtrip(t *testing.T) {
+func TestWriteCarRoundtrip(t *testing.T) {
 	dserv := dstest.Mock()
 	a := dag.NewRawNode([]byte("aaaa"))
 	b := dag.NewRawNode([]byte("bbbb"))
@@ -66,6 +66,79 @@ func TestRoundtrip(t *testing.T) {
 
 		if !has {
 			t.Fatal("should have cid in blockstore")
+		}
+	}
+}
+
+func TestWriteCarIgnoreSetRoundTrip(t *testing.T) {
+	dserv := dstest.Mock()
+	a := dag.NewRawNode([]byte("aaaa"))
+	b := dag.NewRawNode([]byte("bbbb"))
+	c := dag.NewRawNode([]byte("cccc"))
+
+	ignoreC := dag.NewRawNode([]byte("ignoreC"))
+
+	nd1 := &dag.ProtoNode{}
+	nd1.AddNodeLink("cat", a)
+
+	nd2 := &dag.ProtoNode{}
+	nd2.AddNodeLink("first", nd1)
+	nd2.AddNodeLink("dog", b)
+
+	ignoreP := &dag.ProtoNode{}
+	ignoreP.AddNodeLink("ignoreP", nd1)
+	ignoreP.AddNodeLink("geoduck", ignoreC)
+
+	nd3 := &dag.ProtoNode{}
+	nd3.AddNodeLink("second", nd2)
+	nd3.AddNodeLink("bear", c)
+	nd3.AddNodeLink("ignoredLink", ignoreP)
+
+	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3, ignoreC, ignoreP)
+
+	ignoreSet := cid.NewSet()
+	ignoreSet.Add(ignoreP.Cid())
+	ignoreSet.Add(ignoreC.Cid())
+
+	buf := new(bytes.Buffer)
+	if err := WriteCarIgnoreSet(context.Background(), dserv, []cid.Cid{nd3.Cid()}, ignoreSet, buf); err != nil {
+		t.Fatal(err)
+	}
+
+	bserv := dstest.Bserv()
+	ch, err := LoadCar(bserv.Blockstore(), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ch.Roots) != 1 {
+		t.Fatal("should have one root")
+	}
+
+	if !ch.Roots[0].Equals(nd3.Cid()) {
+		t.Fatal("got wrong cid")
+	}
+
+	bs := bserv.Blockstore()
+	for _, nd := range []format.Node{a, b, c, nd1, nd2, nd3} {
+		has, err := bs.Has(nd.Cid())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !has {
+			t.Fatal("should have cid in blockstore")
+		}
+	}
+
+	for _, ignored := range []format.Node{ignoreC, ignoreP} {
+		has, err := bs.Has(ignored.Cid())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if has {
+			t.Fatal("should note have ignored cid in blockstore")
 		}
 	}
 }


### PR DESCRIPTION
### Description
This PR adds a method `WriteCarIgnoreSet` which accepts a set of cids that will not be traversed when writing a car file. 

### Status
If the addition of this method is well received tests will be added next.