### PR TITLE
Add ignore paaram to WriteCar for cids we don't want to write

### DIFF
--- a/car_test.go
+++ b/car_test.go
@@ -43,7 +43,7 @@ func TestRoundtrip(t *testing.T) {
 	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3)
 
 	buf := new(bytes.Buffer)
-	if err := WriteCar(context.Background(), dserv, []cid.Cid{nd3.Cid()}, buf); err != nil {
+	if err := WriteCar(context.Background(), dserv, []cid.Cid{nd3.Cid()}, cid.NewSet(), buf); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Filecoin requirements put us in the position of needing to ignore certain cids (huge sector data graphs) while writing dags to carfiles.  This adds a parameter for ignoring cids in a graph during the write traversal.